### PR TITLE
fix(appenders): caching of levels cleared on appender change

### DIFF
--- a/src/logger/class/LoggerAppenders.ts
+++ b/src/logger/class/LoggerAppenders.ts
@@ -57,6 +57,7 @@ export class LoggerAppenders {
         const instance: BaseAppender = new klass(config);
 
         this._appenders.set(name, {name, instance, config});
+        this._lvls.clear();
         return this;
     }
 
@@ -66,7 +67,11 @@ export class LoggerAppenders {
      * @returns {boolean} Returns true if an element in the Map object existed and has been removed, or false if the element does not exist.
      */
     delete(name: string): boolean {
-        return this._appenders.delete(name);
+        let existed = this._appenders.delete(name);
+        if (existed) {
+            this._lvls.clear();
+        }
+        return existed;
     }
 
     /**
@@ -74,6 +79,7 @@ export class LoggerAppenders {
      */
     clear(): void {
         this._appenders.clear();
+        this._lvls.clear();
     }
 
     /**

--- a/test/logger/class/LoggerAppenders.spec.ts
+++ b/test/logger/class/LoggerAppenders.spec.ts
@@ -15,7 +15,6 @@ class TestAppender extends BaseAppender {
 describe("LoggerAppenders", () => {
     before(() => {
         this.appenders = new LoggerAppenders();
-        this.appenders = new LoggerAppenders();
         this.appenders.set("custom", {type: "test2", levels: ["debug"]});
     });
 
@@ -34,6 +33,29 @@ describe("LoggerAppenders", () => {
         describe("when appender doesn't exists", () => {
             it("should throw an error", () => {
                 assert.throws(() => this.appenders.set("unknow", {type: "unknow"}), "");
+            });
+        });
+
+        describe("caching updated", () => {
+            beforeEach(() => {
+                this.cachedAppenders = new LoggerAppenders();
+                this.cachedAppenders.set("custom", {type: "test2", levels: ["debug"]});
+                this.result = this.cachedAppenders.byLogLevel(levels().DEBUG);
+            });
+            it("when cleared should have no appenders", () => {
+                this.cachedAppenders.clear();
+                this.result = this.cachedAppenders.byLogLevel(levels().DEBUG);
+                expect(this.result).to.be.an("array").lengthOf(0);
+            });
+            it("when deleted should have no appenders", () => {
+                this.cachedAppenders.delete("custom");
+                this.result = this.cachedAppenders.byLogLevel(levels().DEBUG);
+                expect(this.result).to.be.an("array").lengthOf(0);
+            });
+            it("when deleted should have no appenders", () => {
+                this.cachedAppenders.set("custom2", {type: "test2", levels: ["debug"]});
+                this.result = this.cachedAppenders.byLogLevel(levels().DEBUG);
+                expect(this.result).to.be.an("array").lengthOf(2);
             });
         });
     });


### PR DESCRIPTION
fix(appenders): caching of levels cleared on appender change

Whenever the appenders are changed during the lifetime of the Logger the level cache will be cleared in order to pick up the change immediately. This way appenders can be changed at any time.